### PR TITLE
Improvements to the Generation and Critique headers to be valid Markdown

### DIFF
--- a/agents/reflection/src/main/java/org/springframework/ai/openai/samples/helloworld/ReflectionAgent.java
+++ b/agents/reflection/src/main/java/org/springframework/ai/openai/samples/helloworld/ReflectionAgent.java
@@ -52,13 +52,13 @@ public class ReflectionAgent {
     public String run(String userQuestion, int maxIterations) {
 
         String generation = generateChatClient.prompt(userQuestion).call().content();
-        System.out.println("##generation\n\n" + generation);
+        System.out.println("## Generation\n\n" + generation);
         String critique;
         for (int i = 0; i < maxIterations; i++) {
 
             critique = critiqueChatClient.prompt(generation).call().content();
 
-            System.out.println("##Critique\n\n" + critique);
+            System.out.println("## Critique\n\n" + critique);
             if (critique.contains("<OK>")) {
                 System.out.println("\n\nStop sequence found\n\n");
                 break;


### PR DESCRIPTION
Just a few minor cosmetic changes:

- Put a space between the hashmark header markers and "Generation" and "Critique" so that they render correctly as Markdown.
- Capitalize "Generation"
