### PR TITLE
Fixes wrong hardcoded credentials in README

### DIFF
--- a/model-context-protocol/weather/starter-webmvc-oauth2-server/README.md
+++ b/model-context-protocol/weather/starter-webmvc-oauth2-server/README.md
@@ -16,12 +16,12 @@ Obtain a token by calling the `/oauth2/token` endpoint:
 ```shell
 curl -XPOST "http://localhost:8080/oauth2/token" \
   --data grant_type=client_credentials \
-  --user "oidc-client:secret"
+  --user "mcp-client:secret"
 # And copy-paste the access token
 # Or use JQ:
 curl -XPOST "http://localhost:8080/oauth2/token" \
   --data grant_type=client_credentials \
-  --user "oidc-client:secret" | jq -r ".access_token"
+  --user "mcp-client:secret" | jq -r ".access_token"
 ```
 
 Store that token, and then boot up the MCP inspector:


### PR DESCRIPTION
Fixes wrong hardcoded credentials in the example for MCP server with OAuth server configuration, causing the following error:

```
❯ curl -XPOST "http://localhost:8080/oauth2/token" \
  --data grant_type=client_credentials \
  --user "oidc-client:secret"
{"error":"invalid_client"}
```