### PR TITLE
Fix: Update incorrect client ID in mcp/weather/oauth2 README.md

### DIFF
--- a/model-context-protocol/weather/starter-webmvc-oauth2-server/README.md
+++ b/model-context-protocol/weather/starter-webmvc-oauth2-server/README.md
@@ -16,12 +16,12 @@ Obtain a token by calling the `/oauth2/token` endpoint:
 ```shell
 curl -XPOST "http://localhost:8080/oauth2/token" \
   --data grant_type=client_credentials \
-  --user "oidc-client:secret"
+  --user "mcp-client:secret"
 # And copy-paste the access token
 # Or use JQ:
 curl -XPOST "http://localhost:8080/oauth2/token" \
   --data grant_type=client_credentials \
-  --user "oidc-client:secret" | jq -r ".access_token"
+  --user "mcp-client:secret" | jq -r ".access_token"
 ```
 
 Store that token, and then boot up the MCP inspector:


### PR DESCRIPTION
An error was occurring due to an incorrect client ID in `README.md`. This has been updated to the correct client ID specified in [application.yaml](https://github.com/spring-projects/spring-ai-examples/blob/main/model-context-protocol/weather/starter-webmvc-oauth2-server/src/main/resources/application.properties#L14).

### AS-ID
```
curl -XPOST "http://localhost:8080/oauth2/token" \
  --data grant_type=client_credentials \
  --user "oidc-client:secret"
{"error":"invalid_client"}
```
### TO-BE
```
curl -XPOST "http://localhost:8080/oauth2/token" \
--data grant_type=client_credentials \
--user "mcp-client:secret"
{"access_token":"...
```