### PR TITLE
refactor(mcp): update SQLite examples to use new MCP client API

### DIFF
--- a/model-context-protocol/sqlite/chatbot/src/main/java/org/springframework/ai/mcp/samples/sqlite/Application.java
+++ b/model-context-protocol/sqlite/chatbot/src/main/java/org/springframework/ai/mcp/samples/sqlite/Application.java
@@ -14,6 +14,7 @@ import io.modelcontextprotocol.json.McpJsonMapper;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.ai.mcp.McpToolNamePrefixGenerator;
 import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -33,9 +34,11 @@ public class Application {
 			List<McpSyncClient> mcpClients,
 			ConfigurableApplicationContext context) {
 		return args -> {
-
-			var chatClient = chatClientBuilder
-					.defaultToolCallbacks(new SyncMcpToolCallbackProvider(mcpClients))
+			var toolCallbackProvider = SyncMcpToolCallbackProvider.builder()
+				.mcpClients(mcpClients)
+				.toolNamePrefixGenerator(McpToolNamePrefixGenerator.noPrefix())
+				.build();
+			var chatClient = chatClientBuilder.defaultToolCallbacks(toolCallbackProvider)
 					.defaultAdvisors(MessageChatMemoryAdvisor.builder(MessageWindowChatMemory.builder().build()).build())
 					.build();
 

--- a/model-context-protocol/sqlite/simple/src/main/java/org/springframework/ai/mcp/samples/sqlite/Application.java
+++ b/model-context-protocol/sqlite/simple/src/main/java/org/springframework/ai/mcp/samples/sqlite/Application.java
@@ -11,6 +11,7 @@ import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.json.McpJsonMapper;
 
 import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.mcp.McpToolNamePrefixGenerator;
 import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -30,9 +31,11 @@ public class Application {
 			List<McpSyncClient> mcpClients, ConfigurableApplicationContext context) {
 
 		return args -> {
-			var chatClient = chatClientBuilder
-					.defaultToolCallbacks(new SyncMcpToolCallbackProvider(mcpClients))
-					.build();
+			var toolCallbackProvider = SyncMcpToolCallbackProvider.builder()
+				.mcpClients(mcpClients)
+				.toolNamePrefixGenerator(McpToolNamePrefixGenerator.noPrefix())
+				.build();
+			var chatClient = chatClientBuilder.defaultToolCallbacks(toolCallbackProvider).build();
 			System.out.println("Running predefined questions with AI model responses:\n");
 
 			// Question 1


### PR DESCRIPTION
- Replace deprecated StdioServerTransport with StdioClientTransport
- Update SyncMcpToolCallbackProvider to use builder pattern with noPrefix generator
- Change SQLite MCP-Server documentation links from GitHub to PyPI
- Remove obsolete function callback documentation sections
- Streamline MCP client initialization with new timeout configuration

These changes align with the latest Spring AI MCP integration patterns and improve code maintainability across both simple and chatbot examples.