### PR TITLE
Fix runtime errors in starter-stdio-server

### DIFF
--- a/model-context-protocol/weather/starter-stdio-server/README.md
+++ b/model-context-protocol/weather/starter-stdio-server/README.md
@@ -138,7 +138,6 @@ CallToolResult alerts = client.callTool(
 ServerParameters stdioParams = ServerParameters.builder("java")
     .args("-Dspring.ai.mcp.server.transport=STDIO",
           "-Dspring.main.web-application-type=none",
-          "-Dlogging.pattern.console=",
           "-jar",
           "target/mcp-weather-stdio-server-0.0.1-SNAPSHOT.jar")
     .build();
@@ -164,7 +163,6 @@ Use the [starter-default-client](../../client-starter/starter-default-client) to
 java -Dspring.ai.mcp.client.stdio.connections.server1.command=java \
      -Dspring.ai.mcp.client.stdio.connections.server1.args=-jar,/Users/christiantzolov/Dev/projects/spring-ai-examples/model-context-protocol/weather/starter-stdio-server/target/mcp-weather-stdio-server-0.0.1-SNAPSHOT.jar \
      -Dai.user.input='What is the weather in NY?' \
-     -Dlogging.pattern.console= \
      -jar mcp-starter-default-client-0.0.1-SNAPSHOT.jar
 ```
 
@@ -180,7 +178,6 @@ To integrate with Claude Desktop, add the following configuration to your Claude
       "args": [
         "-Dspring.ai.mcp.server.stdio=true",
         "-Dspring.main.web-application-type=none",
-        "-Dlogging.pattern.console=",
         "-jar",
         "/absolute/path/to/mcp-weather-stdio-server-0.0.1-SNAPSHOT.jar"
       ]
@@ -201,7 +198,6 @@ All properties are prefixed with `spring.ai.mcp.server`:
 # Required STDIO Configuration
 spring.main.web-application-type=none
 spring.main.banner-mode=off
-logging.pattern.console=
 
 # Server Configuration
 spring.ai.mcp.server.enabled=true
@@ -217,12 +213,35 @@ spring.ai.mcp.server.prompt-change-notification=true
 logging.file.name=mcp-weather-stdio-server.log
 ```
 
+### Logback Configuration
+
+Redirect all console logs to stderr with `logback-spring.xml`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+    <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+    <appender name="CONSOLE_LOG_STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>${CONSOLE_LOG_CHARSET}</charset>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE_LOG_STDERR" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>
+```
+
 ### Key Configuration Notes
 
 1. **STDIO Mode Requirements**
    - Disable web application type (`spring.main.web-application-type=none`)
    - Disable Spring banner (`spring.main.banner-mode=off`)
-   - Clear console logging pattern (`logging.pattern.console=`)
+   - Configure Logback to output to stderr (`logback-spring.xml`)
 
 2. **Server Type**
    - `SYNC` (default): Uses `McpSyncServer` for straightforward request-response patterns

--- a/model-context-protocol/weather/starter-stdio-server/src/main/resources/application.properties
+++ b/model-context-protocol/weather/starter-stdio-server/src/main/resources/application.properties
@@ -3,7 +3,6 @@ spring.main.web-application-type=none
 # NOTE: You must disable the banner and the console logging 
 # to allow the STDIO transport to work !!!
 spring.main.banner-mode=off
-logging.pattern.console=
 
 spring.ai.mcp.server.name=my-weather-server
 spring.ai.mcp.server.version=0.0.1

--- a/model-context-protocol/weather/starter-stdio-server/src/main/resources/logback-spring.xml
+++ b/model-context-protocol/weather/starter-stdio-server/src/main/resources/logback-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+	<include resource="org/springframework/boot/logging/logback/defaults.xml" />
+	<include resource="org/springframework/boot/logging/logback/file-appender.xml" />
+	<appender name="CONSOLE_LOG_STDERR" class="ch.qos.logback.core.ConsoleAppender">
+		<target>System.err</target>
+		<encoder>
+			<pattern>${CONSOLE_LOG_PATTERN}</pattern>
+			<charset>${CONSOLE_LOG_CHARSET}</charset>
+		</encoder>
+	</appender>
+	<root level="INFO">
+		<appender-ref ref="CONSOLE_LOG_STDERR" />
+		<appender-ref ref="FILE" />
+	</root>
+</configuration>


### PR DESCRIPTION
## Description
This PR updates the [`starter-stdio-server`](https://github.com/spring-projects/spring-ai-examples/tree/main/model-context-protocol/weather/starter-stdio-server) sample linked from the [Official MCP Documentation](https://modelcontextprotocol.io/docs/develop/build-server#java).
It resolves runtime errors caused by improper logging configuration and log output destination.

## Changes
- Logging & STDIO Stability
  - Removed the empty `logging.pattern.console` property to resolve Logback initialization errors.
  - Created `logback-spring.xml` to redirect all console logs to `System.err`. This ensures that `System.out` is reserved exclusively for the MCP JSON-RPC protocol, preventing communication breakdown.
  - Updated [README](https://github.com/spring-projects/spring-ai-examples/blob/main/model-context-protocol/weather/starter-stdio-server/README.md) to reflect the removal of `logging.pattern.console` and the addition of `logback-spring.xml`.

## Testing
I have verified that the server builds and communicates correctly in the following environment:
- Environment: Java 17.0.13 (LTS)
- Build: mvnw clean install (Confirmed successful build)
- Runtime: Verified tool discovery and execution using the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector).

Verification Command:
```powershell
> java --version
java 17.0.13 2024-10-15 LTS
Java(TM) SE Runtime Environment (build 17.0.13+10-LTS-268)
Java HotSpot(TM) 64-Bit Server VM (build 17.0.13+10-LTS-268, mixed mode, sharing)

> mvnw clean install
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

> npx @modelcontextprotocol/inspector java -jar ./target/mcp-weather-stdio-server-0.0.1-SNAPSHOT.jar
```