### PR TITLE
Apply latest M3 upgrade instructions and open-rewrite scripts

### DIFF
--- a/.version-backups/20251125_091005/model-context-protocol/weather/manual-webflux-server/pom.xml
+++ b/.version-backups/20251125_091005/model-context-protocol/weather/manual-webflux-server/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <groupId>org.springframework.ai</groupId>
             <artifactId>mcp-spring-webflux</artifactId>
         </dependency>
 

--- a/model-context-protocol/dynamic-tool-update/client/src/main/java/org/springframework/ai/mcp/samples/client/ClientApplication.java
+++ b/model-context-protocol/dynamic-tool-update/client/src/main/java/org/springframework/ai/mcp/samples/client/ClientApplication.java
@@ -23,7 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.mcp.customizer.McpSyncClientCustomizer;
+import io.modelcontextprotocol.client.McpClient;
+import org.springframework.ai.mcp.customizer.McpClientCustomizer;
 import org.springframework.ai.tool.ToolCallbackProvider;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -87,7 +88,7 @@ public class ClientApplication {
 	}
 
 	@Bean
-	McpSyncClientCustomizer customizeMcpClient() {
+	McpClientCustomizer<McpClient.SyncSpec> customizeMcpClient() {
 		return (name, mcpClientSpec) -> {
 			mcpClientSpec.toolsChangeConsumer(tv -> {
 				logger.info("\nMCP TOOLS CHANGE: " + tv);

--- a/model-context-protocol/sampling/mcp-sampling-client/src/main/java/org/springframework/ai/mcp/samples/client/McpClientApplication.java
+++ b/model-context-protocol/sampling/mcp-sampling-client/src/main/java/org/springframework/ai/mcp/samples/client/McpClientApplication.java
@@ -26,7 +26,8 @@ import io.modelcontextprotocol.spec.McpSchema.CreateMessageResult;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.mcp.SyncMcpToolCallbackProvider;
-import org.springframework.ai.mcp.customizer.McpSyncClientCustomizer;
+import io.modelcontextprotocol.client.McpClient;
+import org.springframework.ai.mcp.customizer.McpClientCustomizer;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -62,7 +63,7 @@ public class McpClientApplication {
 	}
 
 	@Bean
-	McpSyncClientCustomizer samplingCustomizer(Map<String, ChatClient> chatClients) {
+	McpClientCustomizer<McpClient.SyncSpec> samplingCustomizer(Map<String, ChatClient> chatClients) {
 
 		return (name, mcpClientSpec) -> {
 			

--- a/model-context-protocol/sampling/mcp-sampling-server/src/test/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
+++ b/model-context-protocol/sampling/mcp-sampling-server/src/test/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
@@ -20,6 +20,7 @@ import java.io.File;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 
 /**

--- a/model-context-protocol/weather/manual-webflux-server/pom.xml
+++ b/model-context-protocol/weather/manual-webflux-server/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
 
         <dependency>
-            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <groupId>org.springframework.ai</groupId>
             <artifactId>mcp-spring-webflux</artifactId>
         </dependency>
 

--- a/model-context-protocol/weather/manual-webflux-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientSse.java
+++ b/model-context-protocol/weather/manual-webflux-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientSse.java
@@ -15,7 +15,8 @@
 */
 package org.springframework.ai.mcp.sample.client;
 
-import io.modelcontextprotocol.client.transport.WebFluxSseClientTransport;
+import org.springframework.ai.mcp.client.webflux.transport.WebFluxSseClientTransport;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 
 import org.springframework.web.reactive.function.client.WebClient;
@@ -27,7 +28,7 @@ public class ClientSse {
 
 	public static void main(String[] args) {
 		var transport = new WebFluxSseClientTransport(WebClient.builder().baseUrl("http://localhost:8080"),
-				McpJsonMapper.createDefault(), "/sse");
+				McpJsonDefaults.getMapper(), "/sse");
 
 		new SampleClient(transport).run();
 	}

--- a/model-context-protocol/weather/manual-webflux-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
+++ b/model-context-protocol/weather/manual-webflux-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
@@ -20,6 +20,7 @@ import java.io.File;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
 
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 
 /**
@@ -38,7 +39,7 @@ public class ClientStdio {
 					"model-context-protocol/weather/manual-webflux-server/target/mcp-weather-server-0.0.1-SNAPSHOT.jar")
 			.build();
 
-		var transport = new StdioClientTransport(stdioParams, McpJsonMapper.createDefault());
+		var transport = new StdioClientTransport(stdioParams, McpJsonDefaults.getMapper());
 
 		new SampleClient(transport).run();
 	}

--- a/model-context-protocol/weather/manual-webflux-server/src/main/java/org/springframework/ai/mcp/sample/server/McpServerConfig.java
+++ b/model-context-protocol/weather/manual-webflux-server/src/main/java/org/springframework/ai/mcp/sample/server/McpServerConfig.java
@@ -1,11 +1,11 @@
 package org.springframework.ai.mcp.sample.server;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpSyncServer;
 import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
-import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
+import org.springframework.ai.mcp.server.webflux.transport.WebFluxSseServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpServerTransportProvider;
 
@@ -23,7 +23,7 @@ public class McpServerConfig {
 	@Bean
 	@ConditionalOnProperty(prefix = "transport", name = "mode", havingValue = "stdio")
 	public StdioServerTransportProvider stdioServerTransportProvider() {
-		return new StdioServerTransportProvider(McpJsonMapper.createDefault());
+		return new StdioServerTransportProvider(McpJsonDefaults.getMapper());
 	}
 
 	// SSE transport

--- a/model-context-protocol/weather/starter-stdio-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
+++ b/model-context-protocol/weather/starter-stdio-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
@@ -21,6 +21,7 @@ import io.modelcontextprotocol.client.McpClient;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
 import io.modelcontextprotocol.spec.McpSchema.CallToolResult;

--- a/model-context-protocol/weather/starter-webflux-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
+++ b/model-context-protocol/weather/starter-webflux-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
@@ -22,6 +22,7 @@ import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 
 /**

--- a/model-context-protocol/weather/starter-webmvc-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
+++ b/model-context-protocol/weather/starter-webmvc-server/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
@@ -20,6 +20,7 @@ import java.io.File;
 import io.modelcontextprotocol.client.transport.ServerParameters;
 import io.modelcontextprotocol.client.transport.StdioClientTransport;
 import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.json.McpJsonDefaults;
 import io.modelcontextprotocol.json.McpJsonMapper;
 
 /**


### PR DESCRIPTION
Done by running: 

```
# Step 1 – patch the groupIds directly so Maven can load the modules
find . -name "pom.xml" -print0 \
  | xargs -0 perl -i -0pe \
    's{<groupId>io\.modelcontextprotocol\.sdk</groupId>(\s+)<artifactId>mcp-spring-webflux</artifactId>}{<groupId>org.springframework.ai</groupId>$1<artifactId>mcp-spring-webflux</artifactId>}g;
     s{<groupId>io\.modelcontextprotocol\.sdk</groupId>(\s+)<artifactId>mcp-spring-webmvc</artifactId>}{<groupId>org.springframework.ai</groupId>$1<artifactId>mcp-spring-webmvc</artifactId>}g'

# Step 2 – run OpenRewrite to migrate Java imports and remaining POM changes
mvn org.openrewrite.maven:rewrite-maven-plugin:6.32.0:run \
  -Drewrite.configLocation=https://raw.githubusercontent.com/spring-projects/spring-ai/refs/heads/main/src/rewrite/migrate-to-2-0-0-M3.yaml \
  -Drewrite.activeRecipes=org.springframework.ai.migration.M3MigrateMcpSpringTransports \
  -Dmaven.compiler.failOnError=false
```

Depends on https://github.com/spring-projects/spring-ai/pull/5611