### PR TITLE
Add JamJet durable agent demo — crash recovery for Spring AI advisors

### DIFF
--- a/advisors/jamjet-durable-agent-demo/README.md
+++ b/advisors/jamjet-durable-agent-demo/README.md
@@ -1,0 +1,54 @@
+# JamJet Durable Agent Demo
+
+Demonstrates how to add **durable execution** to a Spring AI agent with zero code changes using [JamJet](https://github.com/jamjet-labs/jamjet-spring).
+
+## What you get
+
+By adding `jamjet-spring-boot-starter` to your dependencies, every `ChatClient.call()` automatically gains:
+
+- **Crash recovery** — if the app crashes mid-call, execution resumes from the last checkpoint
+- **Event-sourced audit trails** — every prompt, response, and tool call is logged
+- **Execution tracking** — workflow state visible via the JamJet runtime API
+
+No code changes needed. JamJet integrates via Spring AI's `BaseAdvisor` + `ChatClientCustomizer` pattern.
+
+## Prerequisites
+
+- Java 21+
+- Docker (for JamJet runtime)
+- OpenAI API key
+
+## Running
+
+```bash
+# 1. Start JamJet runtime
+docker run -p 7700:7700 ghcr.io/jamjet-labs/jamjet:latest
+
+# 2. Run the demo
+OPENAI_API_KEY=sk-... mvn spring-boot:run
+```
+
+## What happens
+
+1. The app creates a `ChatClient` with two tools (`getWeather`, `getClothingAdvice`)
+2. JamJet's `DurabilityAdvisor` and `AuditAdvisor` are auto-injected — no manual wiring needed
+3. When the agent runs, JamJet:
+   - Creates a workflow on the runtime
+   - Starts a tracked execution
+   - Records every tool call and LLM response as immutable events
+   - If the process crashes, the next run resumes from the last checkpoint
+
+## Configuration
+
+```properties
+spring.jamjet.runtime-url=http://localhost:7700  # JamJet runtime address
+spring.jamjet.audit.enabled=true                 # Audit trails (default: on)
+spring.jamjet.audit.include-prompts=true          # Log prompt text
+spring.jamjet.audit.include-responses=true        # Log response text
+```
+
+## Learn more
+
+- [JamJet Spring Boot Starter](https://github.com/jamjet-labs/jamjet-spring) — full documentation
+- [JamJet Docs](https://docs.jamjet.dev) — runtime setup, configuration, API reference
+- [Maven Central](https://central.sonatype.com/artifact/dev.jamjet/jamjet-spring-boot-starter) — published artifacts

--- a/advisors/jamjet-durable-agent-demo/pom.xml
+++ b/advisors/jamjet-durable-agent-demo/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.4.1</version>
+		<relativePath/>
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>jamjet-durable-agent-demo</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>jamjet-durable-agent-demo</name>
+	<description>Demo: durable execution for Spring AI agents with JamJet</description>
+
+	<properties>
+		<java.version>21</java.version>
+		<spring-ai.version>1.0.0</spring-ai.version>
+	</properties>
+
+	<dependencies>
+		<!-- Spring AI with OpenAI (also works with Ollama via OpenAI-compatible API) -->
+		<dependency>
+			<groupId>org.springframework.ai</groupId>
+			<artifactId>spring-ai-starter-model-openai</artifactId>
+		</dependency>
+
+		<!-- JamJet — adds durable execution, audit trails, crash recovery -->
+		<dependency>
+			<groupId>dev.jamjet</groupId>
+			<artifactId>jamjet-spring-boot-starter</artifactId>
+			<version>0.1.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.ai</groupId>
+				<artifactId>spring-ai-bom</artifactId>
+				<version>${spring-ai.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/advisors/jamjet-durable-agent-demo/src/main/java/com/example/jamjet_durable_agent/JamjetDurableAgentDemoApplication.java
+++ b/advisors/jamjet-durable-agent-demo/src/main/java/com/example/jamjet_durable_agent/JamjetDurableAgentDemoApplication.java
@@ -1,0 +1,78 @@
+package com.example.jamjet_durable_agent;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Demonstrates JamJet durable execution with Spring AI.
+ *
+ * <p>By adding {@code jamjet-spring-boot-starter} to the classpath,
+ * every {@link ChatClient} call automatically gains:
+ * <ul>
+ *   <li>Crash recovery — resume from last checkpoint</li>
+ *   <li>Event-sourced audit trails — every prompt, response, and tool call logged</li>
+ *   <li>Execution tracking — workflow state visible via JamJet runtime API</li>
+ * </ul>
+ *
+ * <p><strong>No code changes needed.</strong> The {@code JamjetDurabilityAdvisor}
+ * is auto-injected via Spring AI's {@code ChatClientCustomizer}.
+ *
+ * <h2>Running</h2>
+ * <pre>{@code
+ * # 1. Start JamJet runtime
+ * docker run -p 7700:7700 ghcr.io/jamjet-labs/jamjet:latest
+ *
+ * # 2. Run the app
+ * OPENAI_API_KEY=sk-... mvn spring-boot:run
+ * }</pre>
+ */
+@SpringBootApplication
+public class JamjetDurableAgentDemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(JamjetDurableAgentDemoApplication.class, args);
+	}
+
+	@Bean
+	CommandLineRunner demo(ChatClient.Builder chatClientBuilder) {
+		return args -> {
+			// JamjetDurabilityAdvisor + JamjetAuditAdvisor are auto-injected
+			ChatClient chatClient = chatClientBuilder
+					.defaultTools(new ResearchTools())
+					.build();
+
+			// This call is now durable:
+			// - Workflow created on JamJet runtime
+			// - Execution started and tracked
+			// - Tool calls recorded in audit trail
+			// - If the app crashes, execution resumes from last checkpoint
+			String answer = chatClient
+					.prompt("What is the weather in Tokyo and what should I wear?")
+					.call()
+					.content();
+
+			System.out.println("\n--- Agent Response ---");
+			System.out.println(answer);
+			System.out.println("--- Durable execution complete ---");
+		};
+	}
+
+	static class ResearchTools {
+
+		@Tool(description = "Get the current weather for a given city")
+		public String getWeather(String city) {
+			// Simulated weather API — in production this would call a real service.
+			// JamJet records this tool call in the audit trail.
+			return "The weather in " + city + " is 22°C, partly cloudy with light winds.";
+		}
+
+		@Tool(description = "Get clothing recommendations for given weather conditions")
+		public String getClothingAdvice(String conditions) {
+			return "For " + conditions + ": light layers, comfortable shoes, and bring a light jacket.";
+		}
+	}
+}

--- a/advisors/jamjet-durable-agent-demo/src/main/resources/application-ollama.properties
+++ b/advisors/jamjet-durable-agent-demo/src/main/resources/application-ollama.properties
@@ -1,0 +1,4 @@
+# Ollama profile — uses Ollama's OpenAI-compatible API
+spring.ai.openai.base-url=http://localhost:11434
+spring.ai.openai.api-key=ollama
+spring.ai.openai.chat.options.model=llama3.2:3b

--- a/advisors/jamjet-durable-agent-demo/src/main/resources/application.properties
+++ b/advisors/jamjet-durable-agent-demo/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+# Spring AI
+spring.ai.openai.api-key=${OPENAI_API_KEY}
+
+# JamJet runtime
+spring.jamjet.runtime-url=http://localhost:7700
+
+# Audit trail (on by default)
+spring.jamjet.audit.enabled=true
+spring.jamjet.audit.include-prompts=true
+spring.jamjet.audit.include-responses=true

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
 		<module>advisors/recursive-advisor-demo</module>
 		<module>advisors/tool-argument-augmenter-demo</module>
 		<module>advisors/evaluation-recursive-advisor-demo</module>
+		<module>advisors/jamjet-durable-agent-demo</module>
 		
 	</modules>
 


### PR DESCRIPTION
## What

Adds a demo showing how [JamJet](https://github.com/jamjet-labs/jamjet-spring) adds durable execution to Spring AI agents with zero code changes.

## Why

Spring AI has great advisor abstractions but no built-in durability. If an agent crashes mid-tool-call, the work is lost. JamJet fills this gap:

- **One dependency** — `dev.jamjet:jamjet-spring-boot-starter:0.1.0` (Maven Central)
- **Zero code changes** — auto-configures via `ChatClientCustomizer`
- **Crash recovery** — resume from last checkpoint
- **Audit trails** — every prompt, response, tool call logged
- **Works with any model** — OpenAI, Ollama, Anthropic, etc.

## The demo

A simple `CommandLineRunner` that creates a `ChatClient` with tools. JamJet advisors are auto-injected:

```java
ChatClient chatClient = chatClientBuilder
    .defaultTools(new ResearchTools())
    .build();

String answer = chatClient
    .prompt("What is the weather in Tokyo?")
    .call()
    .content();
// This call is now durable — crash recovery + event sourcing
```

Includes an `application-ollama.properties` profile for local testing without API keys.

## Testing

```bash
# Start JamJet runtime
docker run -p 7700:7700 ghcr.io/jamjet-labs/jamjet:latest

# Run with Ollama (local, no API key needed)
mvn spring-boot:run -Dspring-boot.run.profiles=ollama

# Or with OpenAI
OPENAI_API_KEY=sk-... mvn spring-boot:run
```

Gracefully degrades if JamJet runtime is not running — the app works normally, just without durability.
