### PR TITLE
chore: add root .env.example for common provider credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Copy this file to `.env` (or export the variables directly) before running
+# examples that require provider credentials.
+
+# Common OpenAI-based examples
+OPENAI_API_KEY=REPLACE_ME
+
+# Some examples and integration tests still read the Spring-style alias
+SPRING_AI_OPENAI_API_KEY=REPLACE_ME
+
+# Anthropic-based examples
+ANTHROPIC_API_KEY=REPLACE_ME
+
+# Some examples and integration tests still read the Spring-style alias
+SPRING_AI_ANTHROPIC_API_KEY=REPLACE_ME
+
+# Brave-powered MCP and web-search examples
+BRAVE_API_KEY=REPLACE_ME
+
+# Optional: used by misc/claude-skills-demo/document-forge
+CUSTOM_SKILL_ID=


### PR DESCRIPTION
## Summary
Add a root `.env.example` with the most common provider credentials used across examples in this repository.

## Why
Several examples require API keys, but there is currently no single template showing the most common environment variable names. Adding a small root template lowers setup friction without changing runtime behavior.

## Scope
- add a root `.env.example`
- include common OpenAI, Anthropic, Brave, and optional Claude skill variables
- avoid script-internal or generated path variables

## Testing
- template-only changes
- checked the variable names against current example and integration-test usage
