### PR TITLE
docs: align integration-testing README with current layout

### DIFF
--- a/integration-testing/README.md
+++ b/integration-testing/README.md
@@ -13,10 +13,9 @@ integration-testing/
 │   └── IntegrationTestUtils.java  # Common testing functionality
 ├── docs/                      # Integration testing documentation
 │   └── README.md             # Detailed integration testing guide
-└── logs/                     # Centralized log storage
-    ├── background-runs/      # Main test run logs from rit-direct.sh
-    └── integration-tests/    # Individual JBang test logs
 ```
+
+Runtime log directories are created on demand by `run-integration-tests.sh` under `integration-testing/logs/` and are not committed to the repository tree.
 
 ## Quick Start
 
@@ -24,9 +23,6 @@ integration-testing/
 ```bash
 # Recommended: Direct execution with reliable port cleanup
 ./integration-testing/scripts/run-integration-tests.sh
-
-# Alternative: Use the legacy Python orchestrator (may have hanging issues - use run-integration-tests.sh instead)
-# python3 integration-testing/scripts/run_integration_tests.py  # REMOVED - obsolete
 ```
 
 ### Create New Integration Test
@@ -141,6 +137,8 @@ logs/
 └── integration-tests/         # Individual Spring Boot application logs
     └── MODULE-spring-boot-TIMESTAMP.log
 ```
+
+These directories are created the first time `run-integration-tests.sh` is executed.
 
 ### **Persistent Logging Template** (JBang Scripts)
 ```java


### PR DESCRIPTION
## Summary
Align `integration-testing/README.md` with the current repository layout and script behavior.

## Why
The README currently shows `integration-testing/logs/` as if it were a committed directory and still carries obsolete context around removed runner paths. Updating the wording makes the docs match the current repository state more closely.

## Scope
- clarify that log directories are created on demand by `run-integration-tests.sh`
- remove the obsolete quick-start reference to the removed Python orchestrator path
- keep the rest of the framework overview unchanged

## Testing
- documentation-only changes
- verified the README updates against the current `integration-testing/` directory structure and runner script
