### PR TITLE
docs: fix MCP WebMVC starter artifact name

### DIFF
--- a/model-context-protocol/weather/starter-webmvc-server/README.md
+++ b/model-context-protocol/weather/starter-webmvc-server/README.md
@@ -7,7 +7,7 @@ For more information, see the [MCP Server Boot Starter](https://docs.spring.io/s
 ## Overview
 
 The sample showcases:
-- Integration with `spring-ai-mcp-server-webmvc-spring-boot-starter`
+- Integration with `spring-ai-starter-mcp-server-webmvc`
 - Support for both SSE (Server-Sent Events) and STDIO transports
 - Automatic tool registration using Spring AI's `@Tool` annotation
 - Two weather-related tools:
@@ -21,7 +21,7 @@ The project requires the Spring AI MCP Server WebMVC Boot Starter:
 ```xml
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-mcp-server-webmvc-spring-boot-starter</artifactId>
+    <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

Fixes the MCP WebMVC starter artifact name in the weather starter README.

The README currently references:

`spring-ai-mcp-server-webmvc-spring-boot-starter`

but the module POM uses the current artifact:

`spring-ai-starter-mcp-server-webmvc`

## Changes

- Updated the overview section artifact name
- Updated the dependency snippet artifact name
- Aligned README documentation with the module POM

Fixes #68