### PR TITLE
fix(mcp-apps-server): put CSP meta on resource read response

### DIFF
--- a/model-context-protocol/mcp-apps-server/src/main/java/com/example/mcpappsserver/DiceApp.java
+++ b/model-context-protocol/mcp-apps-server/src/main/java/com/example/mcpappsserver/DiceApp.java
@@ -1,5 +1,7 @@
 package com.example.mcpappsserver;
 
+import io.modelcontextprotocol.spec.McpSchema.ReadResourceResult;
+import io.modelcontextprotocol.spec.McpSchema.TextResourceContents;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
 import org.springframework.ai.mcp.annotation.context.MetaProvider;
@@ -21,22 +23,24 @@ public class DiceApp {
   @Value("classpath:/app/dice-app.html")
   private Resource diceAppResource;
 
-  @McpResource(name = "Dice App Resource",
-      uri = "ui://dice/dice-app.html",
-      mimeType = "text/html;profile=mcp-app",
-      metaProvider = CspMetaProvider.class)
-  public String getDiceAppResource() throws IOException {
-    return diceAppResource.getContentAsString(Charset.defaultCharset());
-  }
+  private static final String DICE_APP_URI = "ui://dice/dice-app.html";
 
-  public static final class CspMetaProvider implements MetaProvider {
-    @Override
-    public Map<String, Object> getMeta() {
-      return Map.of("ui",
-          Map.of("csp",
-              Map.of("resourceDomains",
-                  List.of("https://unpkg.com"))));
-    }
+  private static final String DICE_APP_MIME_TYPE = "text/html;profile=mcp-app";
+
+  @McpResource(name = "Dice App Resource",
+      uri = DICE_APP_URI,
+      mimeType = DICE_APP_MIME_TYPE)
+  public ReadResourceResult getDiceAppResource() throws IOException {
+    String html = diceAppResource.getContentAsString(Charset.defaultCharset());
+    return ReadResourceResult.builder(List.of(
+        TextResourceContents.builder(DICE_APP_URI, html)
+            .mimeType(DICE_APP_MIME_TYPE)
+            .meta(Map.of("ui",
+                Map.of("csp",
+                    Map.of("resourceDomains",
+                        List.of("https://unpkg.com")))))
+            .build()))
+        .build();
   }
 
   //
@@ -56,7 +60,7 @@ public class DiceApp {
     public Map<String, Object> getMeta() {
       return Map.of("ui",
           Map.of(
-              "resourceUri", "ui://dice/dice-app.html"));
+              "resourceUri", DICE_APP_URI));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #136

The MCP Apps spec requires `_meta.ui.csp` (and related UI metadata) on the `contents[]` objects returned by the resource **read** callback, not on the resource definition registered via `@McpResource` / `metaProvider`.

This change:
- Removes `CspMetaProvider` from the `@McpResource` registration
- Returns `ReadResourceResult` with `TextResourceContents` that carries `_meta.ui.csp.resourceDomains` for `https://unpkg.com`
- Keeps tool-level `DiceMetaProvider` (`_meta.ui.resourceUri`) unchanged — that belongs on the tool, not the resource definition

## Test plan

- [x] `./gradlew build` in `model-context-protocol/mcp-apps-server` (Java 25 toolchain)
- [x] Spring context loads (`McpAppsServerApplicationTests`)

## AI assistance disclosure

This fix was AI-assisted (Composer/Cursor) and human-reviewed per [Spring AI CONTRIBUTING](https://github.com/spring-projects/spring-ai/blob/main/CONTRIBUTING.md) accountability guidelines.


Made with [Cursor](https://cursor.com)