### PR TITLE
Validate Spring AI version update arguments

### DIFF
--- a/scripts/tests/update-spring-ai-version-tests.sh
+++ b/scripts/tests/update-spring-ai-version-tests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UPDATE_SCRIPT="$(cd "${SCRIPT_DIR}/.." && pwd)/update-spring-ai-version.sh"
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+assert_exit_code() {
+    expected="$1"
+    shift
+
+    set +e
+    "$@" >/tmp/update-version-test.out 2>&1
+    actual=$?
+    set -e
+
+    if [ "${actual}" -ne "${expected}" ]; then
+        cat /tmp/update-version-test.out >&2
+        fail "Expected exit code ${expected}, got ${actual}"
+    fi
+}
+
+echo "Test: rejects missing version"
+assert_exit_code 2 "${UPDATE_SCRIPT}"
+
+echo "Test: rejects extra arguments"
+assert_exit_code 2 "${UPDATE_SCRIPT}" 2.0.0 extra
+
+echo "Test: rejects invalid version"
+assert_exit_code 1 "${UPDATE_SCRIPT}" latest
+
+echo "PASS: update version argument validation"

--- a/scripts/update-spring-ai-version.sh
+++ b/scripts/update-spring-ai-version.sh
@@ -8,8 +8,15 @@
 
 set -e
 
-# Get the version parameter or use default
-VERSION="${1:-2.0.0-RC1}"
+# Require exactly one version parameter
+if [ "$#" -ne 1 ]; then
+    echo "Error: exactly one Spring AI version is required." >&2
+    echo "Usage: $0 <version>" >&2
+    echo "Example: $0 2.0.0-SNAPSHOT" >&2
+    exit 2
+fi
+
+VERSION="$1"
 
 # Validate version format
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(SNAPSHOT|RC[0-9]+|M[0-9]+))?$ ]]; then


### PR DESCRIPTION
## Summary

Improve `scripts/update-spring-ai-version.sh` argument validation.

Previously, running the script without a version silently defaulted to `2.0.0-RC1`, which could unintentionally rewrite many project POM files.

This change:

- requires exactly one Spring AI version argument;
- rejects missing and extra arguments with a usage message;
- preserves existing invalid-version validation;
- adds regression tests for missing, extra, and invalid arguments.

## Testing

- Missing version returns exit code `2`.
- Extra arguments return exit code `2`.
- Invalid version returns exit code `1`.
- No POM files are modified when validation fails.