### PR TITLE
Avoid overflow in merge sort midpoint calculation

### DIFF
--- a/agents/reflection/src/test/java/org/springframework/ai/openai/samples/helloworld/MergeSort.java
+++ b/agents/reflection/src/test/java/org/springframework/ai/openai/samples/helloworld/MergeSort.java
@@ -27,7 +27,7 @@ public class MergeSort {
 
     private static void mergeSort(int[] array, int[] tempArray, int start, int end) {
         if (start < end) {
-            int mid = (start + end) / 2;
+            int mid = start + (end - start) / 2;
 
             // Recursively sort the two halves
             mergeSort(array, tempArray, start, mid);


### PR DESCRIPTION
## Summary

Use an overflow-safe midpoint calculation in `MergeSort`.

The previous implementation used:

```java
(start + end) / 2