### PR TITLE
docs: fix MCP WebMVC starter artifactId in weather sample README

### DIFF
--- a/model-context-protocol/weather/starter-webmvc-server/README.md
+++ b/model-context-protocol/weather/starter-webmvc-server/README.md
@@ -6,7 +6,7 @@ For more information, see the [MCP Server Boot Starter](https://docs.spring.io/s
 
 ## Overview
 
-- Integration with `spring-ai-mcp-server-webmvc-spring-boot-starter`
+- Integration with `spring-ai-starter-mcp-server-webmvc`
 - SSE, Streamable HTTP, and STDIO transport support
 - Automatic tool registration via `@McpTool` annotation (no manual bean wiring required)
 - Two weather tools: forecast by lat/lon and alerts by US state
@@ -16,7 +16,7 @@ For more information, see the [MCP Server Boot Starter](https://docs.spring.io/s
 ```xml
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-mcp-server-webmvc-spring-boot-starter</artifactId>
+    <artifactId>spring-ai-starter-mcp-server-webmvc</artifactId>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
- Fix the incorrect MCP WebMVC starter artifactId in the weather sample README.
- Align the dependency snippet with the current starter artifactId.

Fixes #68

## Testing
- Markdown-only change; reviewed the diff.