### PR TITLE
fix: set MCP app CSP metadata on the resource response

### DIFF
--- a/model-context-protocol/mcp-apps-server/src/main/java/com/example/mcpappsserver/DiceApp.java
+++ b/model-context-protocol/mcp-apps-server/src/main/java/com/example/mcpappsserver/DiceApp.java
@@ -1,8 +1,8 @@
 package com.example.mcpappsserver;
 
+import io.modelcontextprotocol.spec.McpSchema;
 import org.springframework.ai.mcp.annotation.McpResource;
 import org.springframework.ai.mcp.annotation.McpTool;
-import org.springframework.ai.mcp.annotation.context.MetaProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
@@ -23,20 +23,19 @@ public class DiceApp {
 
   @McpResource(name = "Dice App Resource",
       uri = "ui://dice/dice-app.html",
-      mimeType = "text/html;profile=mcp-app",
-      metaProvider = CspMetaProvider.class)
-  public String getDiceAppResource() throws IOException {
-    return diceAppResource.getContentAsString(Charset.defaultCharset());
-  }
-
-  public static final class CspMetaProvider implements MetaProvider {
-    @Override
-    public Map<String, Object> getMeta() {
-      return Map.of("ui",
-          Map.of("csp",
-              Map.of("resourceDomains",
-                  List.of("https://unpkg.com"))));
-    }
+      mimeType = "text/html;profile=mcp-app")
+  public McpSchema.ReadResourceResult getDiceAppResource(McpSchema.ReadResourceRequest request)
+      throws IOException {
+    var content = diceAppResource.getContentAsString(Charset.defaultCharset());
+    return McpSchema.ReadResourceResult.builder(List.of(
+        McpSchema.TextResourceContents.builder(request.uri(), content)
+            .mimeType("text/html;profile=mcp-app")
+            .build()))
+        .meta(Map.of("ui",
+            Map.of("csp",
+                Map.of("resourceDomains",
+                    List.of("https://unpkg.com")))))
+        .build();
   }
 
   //


### PR DESCRIPTION
## Summary
- Move the MCP app CSP metadata to the resource response metadata.
- Keep the sample aligned with the expected MCP Apps resource response shape.

Fixes #136

## Testing
- Built the example module locally and confirmed it compiles.